### PR TITLE
Fix: Set explicit logo dimensions and remove dynamic sizing

### DIFF
--- a/content.js
+++ b/content.js
@@ -748,7 +748,7 @@
   const renderMain = () => {
     const logoUrl = getLogoUrl();
     const titleHtml = state.currentView === 'fetch'
-      ? (logoUrl ? `<img id="ctx-logo" src="${logoUrl}" alt="Fetch Context" style="display:inline-block;vertical-align:middle;" />` : `<span style="color:#2563eb;">${renderLogo(16)}</span> ${renderHeaderTitle()}`)
+      ? (logoUrl ? `<img id="ctx-logo" src="${logoUrl}" alt="Fetch Context" style="display:inline-block;vertical-align:middle;width:20px;height:20px;" />` : `<span style="color:#2563eb;">${renderLogo(16)}</span> ${renderHeaderTitle()}`)
       : `<span style="color:#2563eb;">${state.currentView === 'history' ? icon('history') : icon('settings')}</span> ${renderHeaderTitle()}`;
     const header = `
       <div class="header">
@@ -802,20 +802,6 @@
     });
     
     byId('ctx-new', false)?.addEventListener('click', () => { resetPrompt(); render(); });
-
-    // Match logo height to 75% of NEW button height when present
-    try {
-      const newButton = byId('ctx-new', false);
-      const logoImg = container.querySelector('#ctx-logo');
-      if (newButton && logoImg) {
-        const btnRect = newButton.getBoundingClientRect();
-        const targetHeight = Math.round(btnRect.height * 0.75);
-        if (targetHeight && targetHeight > 0) {
-          logoImg.style.height = targetHeight + 'px';
-          logoImg.style.width = 'auto';
-        }
-      }
-    } catch (_) {}
 
     // Nav
     byId('ctx-nav-fetch', false)?.addEventListener('click', () => { if (state.isCollapsed) state.isCollapsed = false; state.currentView = 'fetch'; render(); });


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Sets the header logo to a fixed 20x20 size and removes the code that dynamically resized it based on the NEW button.
> 
> - **UI/Header**
>   - Set fixed dimensions for the fetch view logo to `20x20` in `content.js` (`<img id="ctx-logo" ... style="...width:20px;height:20px;" />`).
>   - Remove dynamic logo sizing logic that adjusted `#ctx-logo` height relative to the `+ NEW` button.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06ffdc6176c34aa690ca97bd7285996908f17828. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->