### PR TITLE
Refactor header title to display logo or icons based on view

### DIFF
--- a/content.js
+++ b/content.js
@@ -747,9 +747,9 @@
 
   const renderMain = () => {
     const logoUrl = getLogoUrl();
-    const titleHtml = state.currentView === 'fetch'
-      ? (logoUrl ? `<img id="ctx-logo" src="${logoUrl}" alt="Fetch Context" style="display:inline-block;vertical-align:middle;width:20px;height:20px;" />` : `<span style="color:#2563eb;">${renderLogo(16)}</span> ${renderHeaderTitle()}`)
-      : `<span style="color:#2563eb;">${state.currentView === 'history' ? icon('history') : icon('settings')}</span> ${renderHeaderTitle()}`;
+    const titleHtml = logoUrl
+      ? `<img id="ctx-logo" src="${logoUrl}" alt="Fetch Context" style="display:inline-block;vertical-align:middle;width:180px;height:auto;" />`
+      : `<span style="color:#2563eb;">${state.currentView === 'history' ? icon('history') : (state.currentView === 'settings' ? icon('settings') : renderLogo(16))}</span> ${renderHeaderTitle()}`;
     const header = `
       <div class="header">
         <div class="title">${titleHtml}</div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Header now always displays the branding logo (larger image) when available; otherwise falls back to view-specific icons for history/settings or default logo.
> 
> - **UI/Header**:
>   - **Title rendering**: Always show image logo (`logo.png`, width 180px) when available across all views; otherwise show view-specific icon (`history`/`settings`) or default logo.
>   - Removes previous fetch-only logo condition and unifies header title logic in `content.js`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 32cec61be6dafa25b287bc80b9e5f20316d8681d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->